### PR TITLE
Add abuse and contact endpoints

### DIFF
--- a/polyproto/core/routes/main.tsp
+++ b/polyproto/core/routes/main.tsp
@@ -27,6 +27,7 @@ namespace polyproto.core;
 enum Version {
     `v1.0-beta.3`,
     `v1.0-beta.4`,
+    `v1.0-beta.5`,
 }
 
 /**
@@ -38,4 +39,58 @@ enum Version {
 op gatewayUrl(): {
     @body _: url;
     @statusCode statusCode: 200;
+};
+
+@doc("""
+    This actor either does not exist on this home server (anymore), or the actor is not from this home server.
+    """)
+model BadReport {
+    ...BadRequestResponse;
+}
+
+/**
+ * File an abuse report for an actor that is misbehaving either on this home server or on other
+ * home servers/service servers.
+ */
+@route("/abuse")
+@added(Version.`v1.0-beta.5`)
+@summary("File an abuse report - Report an Actor")
+@post
+op reportAbuseFid(
+    @body _b: {
+        @doc("Federation ID of the reported actor")
+        fid: string;
+
+        @doc("Information about why this actor was reported.")
+        reportText: string;
+
+        @doc("This endpoint requires you to identify by completing a key trial.")
+        keyTrial: polyproto.core.models.KeyTrialCompleted;
+    },
+): {
+    @statusCode _: 200;
+
+    @example(#{
+        message: "Thank you for filing a report. Instance moderators will be in touch shortly.",
+    })
+    @body
+    _b: {
+        @doc("An optional message from the home server")
+        message?: string;
+    };
+} | BadReport;
+
+/**
+ * Retrieve contact information for this home server. May include an `adminAccount` federation ID,
+ * if this instance supports some form of text message exchange and such an account exists.
+ */
+@get
+@summary("Retrieve contact information")
+@route("/contact")
+op getContactInfo(): {
+    @statusCode _s: 200;
+    @body _b: {
+        adminAccount?: string;
+        mail: string;
+    };
 };


### PR DESCRIPTION
This PR is a proposal to add `abuse` reporting and `contact` endpoints, adding standardized ways to assist moderation efforts.

## `.p2/core/contact`

The contact endpoint is a simple `GET` endpoint, which returns an email address and, optionally, the federation ID of a dedicated admin/moderator account on this home server, should the home server support a form of text message exchange, and should such an account exist.

## `.p2/core/abuse`

The abuse report endpoint is a `POST` endpoint, with which you can report actors. To report a user, an actor must first request a key trial from this home server and process it into a completed key trial as per the polyproto-core specification. This acts as a simple proof-of-work based method to associate reports with a FID, potentially deterring spammers and making it easier for home server staff to filter out spam reports. The request body is otherwise made up out of the `fid` and `reportText` fields for specifying the reported actor and the report reason, respectively. This proposal does not dictate the maximum length of the `string`-type `reportText` field.

## Further work

If accepted by the community, these endpoints will be integrated into the core specification document, as well as the `polyproto-rs` reference client library and the `sonata` reference home server.